### PR TITLE
feat: make path to typst-ws configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,16 @@
           "group": "navigation"
         }
       ]
+    },
+    "configuration": {
+      "title": "Typst Preview",
+      "properties": {
+        "typst-ws.executable": {
+          "type": "string",
+          "default": "typst-ws",
+          "description": "Path to typst-ws executable"
+        }
+      }
     }
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,10 @@ function loadHTMLFile(context: vscode.ExtensionContext, relativePath: string) {
 	return fileContents;
 }
 
+function getTypstWsPath(): string {
+	return vscode.workspace.getConfiguration().get<string>('typst-ws.executable') || 'typst-ws';
+}
+
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -28,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
 		if (activeEditor) {
 			let filePath = activeEditor.document.uri.fsPath;
 			console.log('File path:', filePath);
-			const serverProcess = spawn(`typst-ws`, ['watch', filePath]);
+			const serverProcess = spawn(getTypstWsPath(), ['watch', filePath]);
 			serverProcess.stdout.on('data', (data) => {
 				console.log(`${data}`);
 			});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -12,4 +12,8 @@ suite('Extension Test Suite', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});
+
+	test('Executable Configuration Test', () => {
+		assert.strictEqual('typst-ws', vscode.workspace.getConfiguration().get<string>('typst-ws.executable'));
+	});
 });


### PR DESCRIPTION
Use key `typst-ws.executable` to configure typst-ws executable.