### PR TITLE
Improve scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
       margin: 0;
       transform-origin: 0 0;
     }
+
+    canvas:not(:last-child) {
+      padding-bottom: 32px;
+    }
   </style>
   <script>
     window.onload = function () {
@@ -24,28 +28,40 @@
         imageContainerWidth = newImageContainerWidth;
         imageContainer.style.transformOrigin = "0px 0px";
         imageContainer.style.transform = `scale(${currentScale})`;
-      }
+      };
 
       // Ctrl+scroll rescaling
+      // will disable auto resizing
+      // fixed factors, same as pdf.js
+      const factors = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.3, 1.5, 1.7,
+        1.9, 2.1, 2.4, 2.7, 3, 3.3, 3.7, 4.1, 4.6, 5.1, 5.7, 6.3, 7, 7.7, 8.5, 9.4, 10];
       imageContainer.addEventListener('wheel', function (event) {
-        const scaleFactor = 1.1;  // 1.1x per scroll
         if (event.ctrlKey) {
           event.preventDefault();
 
+          if (window.onresize !== null) {  // is auto resizing
+            window.onresize = null;
+          }
+
           // Get wheel scroll direction and calculate new scale
-          const delta = (event.deltaY < 0) ? scaleFactor : 1 / scaleFactor;
-          if (currentScale * delta >= 5 || currentScale * delta <= 0.2) {
-            // clamp
+          if (event.deltaY < 0) {  // enlarge
+            if (currentScale >= factors.at(-1)) {  // already large than max factor
+              return;
+            } else {
+              currentScale = factors.filter(x => x > currentScale).at(0);
+            }
+          } else if (event.deltaY > 0) {  // reduce
+            if (currentScale <= factors.at(0)) {
+              return;
+            } else {
+              currentScale = factors.filter(x => x < currentScale).at(-1);
+            }
+          } else {  // no y-axis scroll
             return;
           }
-          currentScale = currentScale * delta;
-
-          // Update transform origin to mouse position
-          const mouseX = event.clientX / currentScale * (1 - delta);
-          const mouseY = event.clientY / currentScale * (1 - delta);
-          imageContainer.style.transformOrigin = `${mouseX}px ${mouseY}px`;
 
           // Apply new scale
+          imageContainer.style.transformOrigin = "0 0";
           imageContainer.style.transform = `scale(${currentScale})`;
         }
       });
@@ -90,7 +106,6 @@
             canvas.width = meta_data.width;
             canvas.height = meta_data.height;
             canvas.style.boxShadow = '0px 4px 12px rgba(89, 85, 101, .2)';
-            canvas.style.padding = '16px 0';
             imageContainer.appendChild(canvas);
             canvas_handle.push(canvas);
           }
@@ -116,8 +131,8 @@
   </script>
 </head>
 
-<body>
-  <div id="imageContainer"></div>
+<body style="padding: 0px 0px 0px 0px;">
+  <div id="imageContainer" style="height: 0px;"></div>
 </body>
 
 </html>


### PR DESCRIPTION
Current behavior is if Ctrl+scroll is not used, then auto scale. Otherwise disable auto scaling on panel width change, and use a fixed table for scaling. Mouse following does not really work, removed.