### PR TITLE
Retry websocket connection on close

### DIFF
--- a/addons/vscode/index.html
+++ b/addons/vscode/index.html
@@ -83,68 +83,8 @@
       let isFirstScale = true;
       let processStart;
 
-      const socket = new WebSocket('ws://127.0.0.1:23625');
-      socket.binaryType = "arraybuffer";
-      socket.addEventListener('open', () => {
-        console.log('WebSocket connection opened');
-      });
-
-      // 当收到WebSocket数据时
-      socket.addEventListener('message', (event) => {
-        // 解析收到的JSON数组
-        if (inflightPages == 0) {
-          processStart = performance.now();
-          meta_data = JSON.parse(event.data);
-          console.log(meta_data);
-          inflightPages = meta_data.page_numbers.length;
-          const total_pages = meta_data.page_total
-          // only run once at start to respect user scaling
-          if (isFirstScale) {
-            // compute scaling factor according to the paper size
-            imageContainerWidth = imageContainer.offsetWidth;
-            currentScale = imageContainerWidth / meta_data.width;
-            imageContainer.style.transformOrigin = "0px 0px";
-            imageContainer.style.transform = `scale(${currentScale})`;
-            isFirstScale = false;
-          }
-
-          while (canvas_handle.length > total_pages) {
-            const removed = canvas_handle.pop();
-            imageContainer.removeChild(removed);
-          }
-          while (canvas_handle.length < total_pages) {
-            const canvas = document.createElement('canvas');
-            canvas.width = meta_data.width;
-            canvas.height = meta_data.height;
-            imageContainer.appendChild(canvas);
-            canvas_handle.push(canvas);
-          }
-          console.log(`meta data process time: ${performance.now() - processStart}ms`)
-        } else {
-          const pageProcessStart = performance.now();
-          const id = meta_data.page_numbers[meta_data.page_numbers.length - inflightPages];
-          console.log(`page ${id} received`)
-          const canvas = canvas_handle[id]
-          const ctx = canvas.getContext('2d');
-          const imageData = new ImageData(new Uint8ClampedArray(event.data), meta_data.width, meta_data.height);
-          ctx.putImageData(imageData, 0, 0);
-          inflightPages--;
-          console.log(`page ${id} process time: ${performance.now() - pageProcessStart}ms`)
-          if (inflightPages == 0) {
-            console.log(`total process time: ${performance.now() - processStart}ms`)
-          }
-        }
-      });
-
-      // 当WebSocket连接关闭时
-      socket.addEventListener('close', () => {
-        console.log('WebSocket connection closed');
-      });
-
-      // 当发生错误时
-      socket.addEventListener('error', (error) => {
-        console.error('WebSocket Error: ', error);
-      });
+      let socket;
+      let socketOpen = false;
       let visibleCanvasRange = []
       const updateVisibleCanvasRange = () => {
         function isInViewport(element) {
@@ -173,7 +113,7 @@
         }
         visibleCanvasRange = newVisibleCanvasRange;
         console.log(`visibleCanvasRange Changed: ${JSON.stringify(visibleCanvasRange)}`);
-        socket.send(JSON.stringify(visibleCanvasRange));
+        if (socketOpen) socket.send(JSON.stringify(visibleCanvasRange));
       };
 
       const debounce = (func, wait, immediate) => {
@@ -195,6 +135,79 @@
       const debouncedUpdateVisibleCanvasRange = debounce(updateVisibleCanvasRange, 100);
       window.addEventListener('scroll', debouncedUpdateVisibleCanvasRange);
       window.addEventListener('resize', debouncedUpdateVisibleCanvasRange);
+
+      function setupSocket() {
+        socket = new WebSocket('ws://127.0.0.1:23625');
+        socket.binaryType = "arraybuffer";
+        socket.addEventListener('open', () => {
+          socketOpen = true;
+          debouncedUpdateVisibleCanvasRange();
+          console.log('WebSocket connection opened');
+        });
+
+        socket.addEventListener('close', () => {
+          socketOpen = false;
+          setTimeout(setupSocket, 1000);
+        });
+
+        // 当收到WebSocket数据时
+        socket.addEventListener('message', (event) => {
+          // 解析收到的JSON数组
+          if (inflightPages == 0) {
+            processStart = performance.now();
+            meta_data = JSON.parse(event.data);
+            console.log(meta_data);
+            inflightPages = meta_data.page_numbers.length;
+            const total_pages = meta_data.page_total
+            // only run once at start to respect user scaling
+            if (isFirstScale) {
+              // compute scaling factor according to the paper size
+              imageContainerWidth = imageContainer.offsetWidth;
+              currentScale = imageContainerWidth / meta_data.width;
+              imageContainer.style.transformOrigin = "0px 0px";
+              imageContainer.style.transform = `scale(${currentScale})`;
+              isFirstScale = false;
+            }
+
+            while (canvas_handle.length > total_pages) {
+              const removed = canvas_handle.pop();
+              imageContainer.removeChild(removed);
+            }
+            while (canvas_handle.length < total_pages) {
+              const canvas = document.createElement('canvas');
+              canvas.width = meta_data.width;
+              canvas.height = meta_data.height;
+              imageContainer.appendChild(canvas);
+              canvas_handle.push(canvas);
+            }
+            console.log(`meta data process time: ${performance.now() - processStart}ms`)
+          } else {
+            const pageProcessStart = performance.now();
+            const id = meta_data.page_numbers[meta_data.page_numbers.length - inflightPages];
+            console.log(`page ${id} received`)
+            const canvas = canvas_handle[id]
+            const ctx = canvas.getContext('2d');
+            const imageData = new ImageData(new Uint8ClampedArray(event.data), meta_data.width, meta_data.height);
+            ctx.putImageData(imageData, 0, 0);
+            inflightPages--;
+            console.log(`page ${id} process time: ${performance.now() - pageProcessStart}ms`)
+            if (inflightPages == 0) {
+              console.log(`total process time: ${performance.now() - processStart}ms`)
+            }
+          }
+        });
+
+        // 当WebSocket连接关闭时
+        socket.addEventListener('close', () => {
+          console.log('WebSocket connection closed');
+        });
+
+        // 当发生错误时
+        socket.addEventListener('error', (error) => {
+          console.error('WebSocket Error: ', error);
+        });
+      }
+      setupSocket();
     };
   </script>
 </head>


### PR DESCRIPTION
With the Remote-SSH feature of VSCode, the port used by `typst-ws` is automatically forwarded to the client (at least on Linux). However, there is a slight delay, and by the time the forwarding is set up, the WebSocket connection had already been attempted (and failed).

This PR makes the WebSocket connection retry itself when it is closed, with a delay of 1 second.