### PR TITLE
fix: load resources when they are symbolic linked

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,19 +3,17 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}/addons/vscode"
-			],
-			"outFiles": [
-				"${workspaceFolder}/addons/vscode/out/**/*.js"
-			],
-			"preLaunchTask": "VS Code Extension Prelaunch"
-		}
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/addons/vscode/out"
+      ],
+      "outFiles": ["${workspaceFolder}/addons/vscode/out/**/*.js"],
+      "preLaunchTask": "VS Code Extension Prelaunch"
+    }
+  ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ actix-web = { version = "4.3.1", features = [] }
 actix-files = { version = "0.6.2", features = [] }
 
 [patch.crates-io]
-typst = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts" }
-typst-library = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts" }
+typst = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.5.0" }
+typst-library = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.5.0" }
 typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", tag = "v0.2.3", package = "typst-ts-svg-exporter" }
 typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", tag = "v0.2.3", package = "typst-ts-core" }
 typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", tag = "v0.2.3", package = "typst-ts-compiler" }

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -10,18 +10,18 @@ import { WebSocket } from 'ws';
 type ScrollSyncMode = "never" | "onSelectionChange";
 
 async function loadHTMLFile(context: vscode.ExtensionContext, relativePath: string) {
-	const filePath = path.resolve(__dirname, relativePath);
+	const filePath = path.resolve(context.extensionPath, relativePath);
 	const fileContents = await readFile(filePath, 'utf8');
 	return fileContents;
 }
 
-export async function getTypstWsPath(): Promise<string> {
+export async function getTypstWsPath(context: vscode.ExtensionContext): Promise<string> {
 	const state = getTypstWsPath as unknown as any;
 	(!state.BINARY_NAME) && (state.BINARY_NAME = "typst-ws");
 	(!state.getConfig) && (state.getConfig = (
 		() => vscode.workspace.getConfiguration().get<string>('typst-preview.executable')));
 
-	const bundledPath = path.resolve(__dirname, state.BINARY_NAME);
+	const bundledPath = path.resolve(context.extensionPath, state.BINARY_NAME);
 	const configPath = state.getConfig();
 
 	if (state.bundledPath === bundledPath && state.configPath === configPath) {
@@ -232,7 +232,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 
 	const refreshStyle = vscode.workspace.getConfiguration().get<string>('typst-preview.refresh') || "onSave";
 	const scrollSyncMode = vscode.workspace.getConfiguration().get<ScrollSyncMode>('typst-preview.scrollSync') || "never";
-	const fontendPath = path.resolve(__dirname, "frontend");
+	const fontendPath = path.resolve(context.extensionPath, "frontend");
 	const { shadowFilePath } = await watchEditorFiles();
 	const { serverProcess, port } = await launchTypstWs(task.kind === 'browser' ? fontendPath : null);
 
@@ -343,7 +343,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 
 	async function launchTypstWs(frontendPath: null | string) {
 		const filePathToWatch = refreshStyle === "onSave" ? filePath : shadowFilePath;
-		const serverPath = await getTypstWsPath();
+		const serverPath = await getTypstWsPath(context);
 		console.log(`Watching ${filePathToWatch} for changes`);
 		const projectRoot = getProjectRoot(filePath);
 		const rootArgs = projectRoot ? ["--root", projectRoot] : [];

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -15,13 +15,13 @@ async function loadHTMLFile(context: vscode.ExtensionContext, relativePath: stri
 	return fileContents;
 }
 
-export async function getTypstWsPath(context: vscode.ExtensionContext): Promise<string> {
+export async function getTypstWsPath(extensionPath?: string): Promise<string> {
 	const state = getTypstWsPath as unknown as any;
 	(!state.BINARY_NAME) && (state.BINARY_NAME = "typst-ws");
 	(!state.getConfig) && (state.getConfig = (
 		() => vscode.workspace.getConfiguration().get<string>('typst-preview.executable')));
 
-	const bundledPath = path.resolve(context.extensionPath, state.BINARY_NAME);
+	const bundledPath = path.resolve(extensionPath || __dirname, state.BINARY_NAME);
 	const configPath = state.getConfig();
 
 	if (state.bundledPath === bundledPath && state.configPath === configPath) {
@@ -343,7 +343,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 
 	async function launchTypstWs(frontendPath: null | string) {
 		const filePathToWatch = refreshStyle === "onSave" ? filePath : shadowFilePath;
-		const serverPath = await getTypstWsPath(context);
+		const serverPath = await getTypstWsPath(context.extensionPath);
 		console.log(`Watching ${filePathToWatch} for changes`);
 		const projectRoot = getProjectRoot(filePath);
 		const rootArgs = projectRoot ? ["--root", projectRoot] : [];


### PR DESCRIPTION
See discussion, https://github.com/hediet/vscode-drawio/issues/141.

> I just tested again on a new device. I've found that on my system, the issue is because VSCode's data directory is a symbolic link/junction. Unfortunately, the Scoop package installer creates the data directory this way. Probably VSCode's webview-resource protocol is not ready for this kind of configurations.

Fix it according to https://github.com/hediet/vscode-drawio/pull/152.
