### PR TITLE
fix: panel scroll to location only if by user selection

### DIFF
--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -245,8 +245,12 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 
 	const src2docHandler = (e: vscode.TextEditorSelectionChangeEvent) => {
 		if (e.textEditor === activeEditor) {
-			console.log('selection changed, sending src2doc jump request');
-			panelScrollTo(bindDocument, activeEditor);
+			const kind = e.kind;
+			console.log(`selection changed, kind: ${kind && vscode.TextEditorSelectionChangeKind[kind]}`);
+			if (kind === vscode.TextEditorSelectionChangeKind.Mouse || kind === vscode.TextEditorSelectionChangeKind.Keyboard) {
+				console.log(`selection changed, sending src2doc jump request`);
+				panelScrollTo(bindDocument, activeEditor);
+			}
 		}
 	};
 	


### PR DESCRIPTION
Ignore `vscode.TextEditorSelectionChangeEvent` which is triggered by some commands (e. g. click the elements in the WebView and jump to source loc).
After this commit, send `panelScrollTo` request to `typst-ws` only if the selection change is taken by user's mouse or keyboard.
